### PR TITLE
Add capacity release HTTP APIs

### DIFF
--- a/src/Client.Http/Client.Http/Generated/ClusterClient.cs
+++ b/src/Client.Http/Client.Http/Generated/ClusterClient.cs
@@ -884,7 +884,7 @@ namespace Microsoft.ServiceFabric.Client.Http
         }
 
         /// <inheritdoc />
-        public Task<IEnumerable<CapacityReleaseEstimate>> GetCapacityReleaseEstimationAsync(
+        public Task<CapacityReleaseEstimationResult> GetCapacityReleaseEstimationAsync(
             long? serverTimeout = 60,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -907,7 +907,7 @@ namespace Microsoft.ServiceFabric.Client.Http
                 return request;
             }
 
-            return this.httpClient.SendAsyncGetResponseAsList(RequestFunc, url, CapacityReleaseEstimateConverter.Deserialize, requestId, cancellationToken);
+            return this.httpClient.SendAsyncGetResponse(RequestFunc, url, CapacityReleaseEstimationResultConverter.Deserialize, requestId, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Client.Http/Client.Http/Generated/ClusterClient.cs
+++ b/src/Client.Http/Client.Http/Generated/ClusterClient.cs
@@ -885,15 +885,20 @@ namespace Microsoft.ServiceFabric.Client.Http
 
         /// <inheritdoc />
         public Task<CapacityReleaseEstimationResult> GetCapacityReleaseEstimationAsync(
+            ContinuationToken continuationToken = default(ContinuationToken),
+            long? maxResults = 0,
             long? serverTimeout = 60,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            maxResults?.ThrowIfLessThan("maxResults", 0);
             serverTimeout?.ThrowIfOutOfInclusiveRange("serverTimeout", 1, 4294967295);
             var requestId = Guid.NewGuid().ToString();
             var url = "$/GetCapacityReleaseEstimation";
             var queryParams = new List<string>();
             
             // Append to queryParams if not null.
+            continuationToken?.AddToQueryParameters(queryParams, $"ContinuationToken={continuationToken.ToString()}");
+            maxResults?.AddToQueryParameters(queryParams, $"MaxResults={maxResults}");
             serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
             queryParams.Add("api-version=11.9");
             url += "?" + string.Join("&", queryParams);

--- a/src/Client.Http/Client.Http/Generated/ClusterClient.cs
+++ b/src/Client.Http/Client.Http/Generated/ClusterClient.cs
@@ -827,6 +827,90 @@ namespace Microsoft.ServiceFabric.Client.Http
         }
 
         /// <inheritdoc />
+        public Task<CapacityReleaseLevelResult> GetCapacityReleaseLevelAsync(
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            serverTimeout?.ThrowIfOutOfInclusiveRange("serverTimeout", 1, 4294967295);
+            var requestId = Guid.NewGuid().ToString();
+            var url = "$/GetCapacityReleaseLevel";
+            var queryParams = new List<string>();
+            
+            // Append to queryParams if not null.
+            serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
+            queryParams.Add("api-version=11.9");
+            url += "?" + string.Join("&", queryParams);
+            
+            HttpRequestMessage RequestFunc()
+            {
+                var request = new HttpRequestMessage()
+                {
+                    Method = HttpMethod.Get,
+                };
+                return request;
+            }
+
+            return this.httpClient.SendAsyncGetResponse(RequestFunc, url, CapacityReleaseLevelResultConverter.Deserialize, requestId, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task SetCapacityReleaseLevelAsync(
+            CapacityReleaseLevel? level,
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            level.ThrowIfNull(nameof(level));
+            serverTimeout?.ThrowIfOutOfInclusiveRange("serverTimeout", 1, 4294967295);
+            var requestId = Guid.NewGuid().ToString();
+            var url = "$/SetCapacityReleaseLevel";
+            var queryParams = new List<string>();
+            
+            // Append to queryParams if not null.
+            level?.AddToQueryParameters(queryParams, $"Level={level.ToString()}");
+            serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
+            queryParams.Add("api-version=11.9");
+            url += "?" + string.Join("&", queryParams);
+            
+            HttpRequestMessage RequestFunc()
+            {
+                var request = new HttpRequestMessage()
+                {
+                    Method = HttpMethod.Post,
+                };
+                return request;
+            }
+
+            return this.httpClient.SendAsync(RequestFunc, url, requestId, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<IEnumerable<CapacityReleaseEstimate>> GetCapacityReleaseEstimationAsync(
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            serverTimeout?.ThrowIfOutOfInclusiveRange("serverTimeout", 1, 4294967295);
+            var requestId = Guid.NewGuid().ToString();
+            var url = "$/GetCapacityReleaseEstimation";
+            var queryParams = new List<string>();
+            
+            // Append to queryParams if not null.
+            serverTimeout?.AddToQueryParameters(queryParams, $"timeout={serverTimeout}");
+            queryParams.Add("api-version=11.9");
+            url += "?" + string.Join("&", queryParams);
+            
+            HttpRequestMessage RequestFunc()
+            {
+                var request = new HttpRequestMessage()
+                {
+                    Method = HttpMethod.Get,
+                };
+                return request;
+            }
+
+            return this.httpClient.SendAsyncGetResponseAsList(RequestFunc, url, CapacityReleaseEstimateConverter.Deserialize, requestId, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public Task ToggleVerboseServicePlacementHealthReportingAsync(
             bool? enabled,
             long? serverTimeout = 60,

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseActionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseActionConverter.cs
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CapacityReleaseAction" />.
+    /// </summary>
+    internal class CapacityReleaseActionConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static CapacityReleaseAction? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(CapacityReleaseAction);
+
+            if (string.Compare(value, "None", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseAction.None;
+            }
+            else if (string.Compare(value, "DropToZero", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseAction.DropToZero;
+            }
+            else if (string.Compare(value, "DropToMin", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseAction.DropToMin;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, CapacityReleaseAction? value)
+        {
+            switch (value)
+            {
+                case CapacityReleaseAction.None:
+                    writer.WriteStringValue("None");
+                    break;
+                case CapacityReleaseAction.DropToZero:
+                    writer.WriteStringValue("DropToZero");
+                    break;
+                case CapacityReleaseAction.DropToMin:
+                    writer.WriteStringValue("DropToMin");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type CapacityReleaseAction");
+            }
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimateConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimateConverter.cs
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CapacityReleaseEstimate" />.
+    /// </summary>
+    internal class CapacityReleaseEstimateConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseEstimate Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseEstimate GetFromJsonProperties(JsonReader reader)
+        {
+            var level = default(CapacityReleaseLevel?);
+            var metricName = default(string);
+            var usedCapacity = default(long?);
+            var totalCapacity = default(long?);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("Level", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    level = CapacityReleaseLevelConverter.Deserialize(reader);
+                }
+                else if (string.Compare("MetricName", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    metricName = reader.ReadValueAsString();
+                }
+                else if (string.Compare("UsedCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    usedCapacity = reader.ReadValueAsLong();
+                }
+                else if (string.Compare("TotalCapacity", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    totalCapacity = reader.ReadValueAsLong();
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new CapacityReleaseEstimate(
+                level: level,
+                metricName: metricName,
+                usedCapacity: usedCapacity,
+                totalCapacity: totalCapacity);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, CapacityReleaseEstimate obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            writer.WriteProperty(obj.Level, "Level", CapacityReleaseLevelConverter.Serialize);
+            writer.WriteProperty(obj.MetricName, "MetricName", JsonWriterExtensions.WriteStringValue);
+            writer.WriteProperty(obj.UsedCapacity, "UsedCapacity", JsonWriterExtensions.WriteLongValue);
+            writer.WriteProperty(obj.TotalCapacity, "TotalCapacity", JsonWriterExtensions.WriteLongValue);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimationResultConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimationResultConverter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
         internal static CapacityReleaseEstimationResult GetFromJsonProperties(JsonReader reader)
         {
             var items = default(IEnumerable<CapacityReleaseEstimate>);
-            var recommendedLevel = default(CapacityReleaseLevel?);
+            var continuationToken = default(ContinuationToken);
 
             do
             {
@@ -43,9 +43,9 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     items = reader.ReadList(CapacityReleaseEstimateConverter.Deserialize);
                 }
-                else if (string.Compare("RecommendedLevel", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Compare("ContinuationToken", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    recommendedLevel = CapacityReleaseLevelConverter.Deserialize(reader);
+                    continuationToken = ContinuationTokenConverter.Deserialize(reader);
                 }
                 else
                 {
@@ -56,7 +56,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
 
             return new CapacityReleaseEstimationResult(
                 items: items,
-                recommendedLevel: recommendedLevel);
+                continuationToken: continuationToken);
         }
 
         /// <summary>
@@ -68,7 +68,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
         {
             // Required properties are always serialized, optional properties are serialized when not null.
             writer.WriteStartObject();
-            writer.WriteProperty(obj.RecommendedLevel, "RecommendedLevel", CapacityReleaseLevelConverter.Serialize);
+            if (obj.ContinuationToken != null)
+            {
+                writer.WriteProperty(obj.ContinuationToken, "ContinuationToken", ContinuationTokenConverter.Serialize);
+            }
             writer.WriteEnumerableProperty(obj.Items, "Items", CapacityReleaseEstimateConverter.Serialize);
             writer.WriteEndObject();
         }

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimationResultConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseEstimationResultConverter.cs
@@ -1,0 +1,76 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CapacityReleaseEstimationResult" />.
+    /// </summary>
+    internal class CapacityReleaseEstimationResultConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseEstimationResult Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseEstimationResult GetFromJsonProperties(JsonReader reader)
+        {
+            var items = default(IEnumerable<CapacityReleaseEstimate>);
+            var recommendedLevel = default(CapacityReleaseLevel?);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("Items", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    items = reader.ReadList(CapacityReleaseEstimateConverter.Deserialize);
+                }
+                else if (string.Compare("RecommendedLevel", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    recommendedLevel = CapacityReleaseLevelConverter.Deserialize(reader);
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new CapacityReleaseEstimationResult(
+                items: items,
+                recommendedLevel: recommendedLevel);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, CapacityReleaseEstimationResult obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            writer.WriteProperty(obj.RecommendedLevel, "RecommendedLevel", CapacityReleaseLevelConverter.Serialize);
+            writer.WriteEnumerableProperty(obj.Items, "Items", CapacityReleaseEstimateConverter.Serialize);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseLevelConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseLevelConverter.cs
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CapacityReleaseLevel" />.
+    /// </summary>
+    internal class CapacityReleaseLevelConverter
+    {
+        /// <summary>
+        /// Gets the enum value by reading string value from reader.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The enum Value.</returns>
+        public static CapacityReleaseLevel? Deserialize(JsonReader reader)
+        {
+            var value = reader.ReadValueAsString();
+            var obj = default(CapacityReleaseLevel);
+
+            if (string.Compare(value, "None", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseLevel.None;
+            }
+            else if (string.Compare(value, "Minor", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseLevel.Minor;
+            }
+            else if (string.Compare(value, "Major", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                obj = CapacityReleaseLevel.Major;
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Serializes the enum value.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The object to serialize to JSON.</param>
+        public static void Serialize(JsonWriter writer, CapacityReleaseLevel? value)
+        {
+            switch (value)
+            {
+                case CapacityReleaseLevel.None:
+                    writer.WriteStringValue("None");
+                    break;
+                case CapacityReleaseLevel.Minor:
+                    writer.WriteStringValue("Minor");
+                    break;
+                case CapacityReleaseLevel.Major:
+                    writer.WriteStringValue("Major");
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid value {value.ToString()} for enum type CapacityReleaseLevel");
+            }
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseLevelResultConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/CapacityReleaseLevelResultConverter.cs
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Client.Http.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ServiceFabric.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converter for <see cref="CapacityReleaseLevelResult" />.
+    /// </summary>
+    internal class CapacityReleaseLevelResultConverter
+    {
+        /// <summary>
+        /// Deserializes the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseLevelResult Deserialize(JsonReader reader)
+        {
+            return reader.Deserialize(GetFromJsonProperties);
+        }
+
+        /// <summary>
+        /// Gets the object from Json properties.
+        /// </summary>
+        /// <param name="reader">The <see cref="T: Newtonsoft.Json.JsonReader" /> to read from, reader must be placed at first property.</param>
+        /// <returns>The object Value.</returns>
+        internal static CapacityReleaseLevelResult GetFromJsonProperties(JsonReader reader)
+        {
+            var level = default(CapacityReleaseLevel?);
+
+            do
+            {
+                var propName = reader.ReadPropertyName();
+                if (string.Compare("Level", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    level = CapacityReleaseLevelConverter.Deserialize(reader);
+                }
+                else
+                {
+                    reader.SkipPropertyValue();
+                }
+            }
+            while (reader.TokenType != JsonToken.EndObject);
+
+            return new CapacityReleaseLevelResult(
+                level: level);
+        }
+
+        /// <summary>
+        /// Serializes the object to JSON.
+        /// </summary>
+        /// <param name="writer">The <see cref="T: Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="obj">The object to serialize to JSON.</param>
+        internal static void Serialize(JsonWriter writer, CapacityReleaseLevelResult obj)
+        {
+            // Required properties are always serialized, optional properties are serialized when not null.
+            writer.WriteStartObject();
+            writer.WriteProperty(obj.Level, "Level", CapacityReleaseLevelConverter.Serialize);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
@@ -44,6 +44,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
             var isDefaultMoveCostSpecified = default(bool?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
@@ -108,6 +109,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("IsDefaultMoveCostSpecified", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     isDefaultMoveCostSpecified = reader.ReadValueAsBool();
+                }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ServicePackageActivationMode", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -196,6 +201,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
                 isDefaultMoveCostSpecified: isDefaultMoveCostSpecified,
+                capacityReleaseAction: capacityReleaseAction,
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
@@ -232,6 +238,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.MinReplicaSetSize, "MinReplicaSetSize", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.HasPersistedState, "HasPersistedState", JsonWriterExtensions.WriteBoolValue);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteProperty(obj.ServicePackageActivationMode, "ServicePackageActivationMode", ServicePackageActivationModeConverter.Serialize);
             if (obj.ApplicationName != null)
             {

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceDescriptionConverter.cs
@@ -44,7 +44,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
             var isDefaultMoveCostSpecified = default(bool?);
-            var capacityReleaseAction = default(CapacityReleaseAction?);
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
@@ -62,6 +61,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var auxiliaryReplicaCount = default(int?);
             var serviceSensitivityDescription = default(ServiceSensitivityDescription);
             var serviceOptions = default(int?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
 
             do
             {
@@ -109,10 +109,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("IsDefaultMoveCostSpecified", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     isDefaultMoveCostSpecified = reader.ReadValueAsBool();
-                }
-                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ServicePackageActivationMode", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -182,6 +178,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     serviceOptions = reader.ReadValueAsInt();
                 }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -201,7 +201,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
                 isDefaultMoveCostSpecified: isDefaultMoveCostSpecified,
-                capacityReleaseAction: capacityReleaseAction,
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
@@ -218,7 +217,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 replicaLifecycleDescription: replicaLifecycleDescription,
                 auxiliaryReplicaCount: auxiliaryReplicaCount,
                 serviceSensitivityDescription: serviceSensitivityDescription,
-                serviceOptions: serviceOptions);
+                serviceOptions: serviceOptions,
+                capacityReleaseAction: capacityReleaseAction);
         }
 
         /// <summary>
@@ -238,7 +238,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.MinReplicaSetSize, "MinReplicaSetSize", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.HasPersistedState, "HasPersistedState", JsonWriterExtensions.WriteBoolValue);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
-            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteProperty(obj.ServicePackageActivationMode, "ServicePackageActivationMode", ServicePackageActivationModeConverter.Serialize);
             if (obj.ApplicationName != null)
             {
@@ -340,6 +339,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.ServiceOptions, "ServiceOptions", JsonWriterExtensions.WriteIntValue);
             }
 
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteEndObject();
         }
     }

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>);
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
-            var capacityReleaseAction = default(CapacityReleaseAction?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
             var serviceTags = default(ServiceTags);
@@ -54,6 +53,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var replicaLifecycleDescription = default(ReplicaLifecycleDescription);
             var auxiliaryReplicaCount = default(int?);
             var serviceSensitivityDescription = default(ServiceSensitivityDescription);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
 
             do
             {
@@ -81,10 +81,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("DefaultMoveCost", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     defaultMoveCost = MoveCostConverter.Deserialize(reader);
-                }
-                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ScalingPolicies", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -142,6 +138,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     serviceSensitivityDescription = ServiceSensitivityDescriptionConverter.Deserialize(reader);
                 }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -156,7 +156,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 loadMetrics: loadMetrics,
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
-                capacityReleaseAction: capacityReleaseAction,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
                 serviceTags: serviceTags,
@@ -170,7 +169,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 dropSourceReplicaOnMove: dropSourceReplicaOnMove,
                 replicaLifecycleDescription: replicaLifecycleDescription,
                 auxiliaryReplicaCount: auxiliaryReplicaCount,
-                serviceSensitivityDescription: serviceSensitivityDescription);
+                serviceSensitivityDescription: serviceSensitivityDescription,
+                capacityReleaseAction: capacityReleaseAction);
         }
 
         /// <summary>
@@ -184,7 +184,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteStartObject();
             writer.WriteProperty(obj.ServiceKind, "ServiceKind", ServiceKindConverter.Serialize);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
-            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             if (obj.Flags != null)
             {
                 writer.WriteProperty(obj.Flags, "Flags", JsonWriterExtensions.WriteStringValue);
@@ -280,6 +279,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.ServiceSensitivityDescription, "ServiceSensitivityDescription", ServiceSensitivityDescriptionConverter.Serialize);
             }
 
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteEndObject();
         }
     }

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatefulServiceUpdateDescriptionConverter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>);
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
             var serviceTags = default(ServiceTags);
@@ -80,6 +81,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("DefaultMoveCost", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     defaultMoveCost = MoveCostConverter.Deserialize(reader);
+                }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ScalingPolicies", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -151,6 +156,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 loadMetrics: loadMetrics,
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
+                capacityReleaseAction: capacityReleaseAction,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
                 serviceTags: serviceTags,
@@ -178,6 +184,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteStartObject();
             writer.WriteProperty(obj.ServiceKind, "ServiceKind", ServiceKindConverter.Serialize);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             if (obj.Flags != null)
             {
                 writer.WriteProperty(obj.Flags, "Flags", JsonWriterExtensions.WriteStringValue);

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
@@ -44,6 +44,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
             var isDefaultMoveCostSpecified = default(bool?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
@@ -103,6 +104,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("IsDefaultMoveCostSpecified", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     isDefaultMoveCostSpecified = reader.ReadValueAsBool();
+                }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ServicePackageActivationMode", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -171,6 +176,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
                 isDefaultMoveCostSpecified: isDefaultMoveCostSpecified,
+                capacityReleaseAction: capacityReleaseAction,
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
@@ -200,6 +206,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.PartitionDescription, "PartitionDescription", PartitionSchemeDescriptionConverter.Serialize);
             writer.WriteProperty(obj.InstanceCount, "InstanceCount", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteProperty(obj.ServicePackageActivationMode, "ServicePackageActivationMode", ServicePackageActivationModeConverter.Serialize);
             if (obj.ApplicationName != null)
             {

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceDescriptionConverter.cs
@@ -44,7 +44,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
             var isDefaultMoveCostSpecified = default(bool?);
-            var capacityReleaseAction = default(CapacityReleaseAction?);
             var servicePackageActivationMode = default(ServicePackageActivationMode?);
             var serviceDnsName = default(string);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
@@ -57,6 +56,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var instanceLifecycleDescription = default(InstanceLifecycleDescription);
             var instanceRestartWaitDurationSeconds = default(long?);
             var serviceOptions = default(int?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
 
             do
             {
@@ -104,10 +104,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("IsDefaultMoveCostSpecified", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     isDefaultMoveCostSpecified = reader.ReadValueAsBool();
-                }
-                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ServicePackageActivationMode", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -157,6 +153,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     serviceOptions = reader.ReadValueAsInt();
                 }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -176,7 +176,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
                 isDefaultMoveCostSpecified: isDefaultMoveCostSpecified,
-                capacityReleaseAction: capacityReleaseAction,
                 servicePackageActivationMode: servicePackageActivationMode,
                 serviceDnsName: serviceDnsName,
                 scalingPolicies: scalingPolicies,
@@ -188,7 +187,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 instanceCloseDelayDurationSeconds: instanceCloseDelayDurationSeconds,
                 instanceLifecycleDescription: instanceLifecycleDescription,
                 instanceRestartWaitDurationSeconds: instanceRestartWaitDurationSeconds,
-                serviceOptions: serviceOptions);
+                serviceOptions: serviceOptions,
+                capacityReleaseAction: capacityReleaseAction);
         }
 
         /// <summary>
@@ -206,7 +206,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteProperty(obj.PartitionDescription, "PartitionDescription", PartitionSchemeDescriptionConverter.Serialize);
             writer.WriteProperty(obj.InstanceCount, "InstanceCount", JsonWriterExtensions.WriteIntValue);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
-            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteProperty(obj.ServicePackageActivationMode, "ServicePackageActivationMode", ServicePackageActivationModeConverter.Serialize);
             if (obj.ApplicationName != null)
             {
@@ -293,6 +292,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.ServiceOptions, "ServiceOptions", JsonWriterExtensions.WriteIntValue);
             }
 
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteEndObject();
         }
     }

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>);
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
             var serviceTags = default(ServiceTags);
@@ -76,6 +77,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("DefaultMoveCost", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     defaultMoveCost = MoveCostConverter.Deserialize(reader);
+                }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ScalingPolicies", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -131,6 +136,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 loadMetrics: loadMetrics,
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
+                capacityReleaseAction: capacityReleaseAction,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
                 serviceTags: serviceTags,
@@ -154,6 +160,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteStartObject();
             writer.WriteProperty(obj.ServiceKind, "ServiceKind", ServiceKindConverter.Serialize);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             if (obj.Flags != null)
             {
                 writer.WriteProperty(obj.Flags, "Flags", JsonWriterExtensions.WriteStringValue);

--- a/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
+++ b/src/Client.Http/Client.Http/Generated/Serialization/StatelessServiceUpdateDescriptionConverter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>);
             var servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>);
             var defaultMoveCost = default(MoveCost?);
-            var capacityReleaseAction = default(CapacityReleaseAction?);
             var scalingPolicies = default(IEnumerable<ScalingPolicyDescription>);
             var serviceDnsName = default(string);
             var serviceTags = default(ServiceTags);
@@ -50,6 +49,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             var instanceCloseDelayDurationSeconds = default(string);
             var instanceLifecycleDescription = default(InstanceLifecycleDescription);
             var instanceRestartWaitDurationSeconds = default(string);
+            var capacityReleaseAction = default(CapacityReleaseAction?);
 
             do
             {
@@ -77,10 +77,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 else if (string.Compare("DefaultMoveCost", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     defaultMoveCost = MoveCostConverter.Deserialize(reader);
-                }
-                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
                 }
                 else if (string.Compare("ScalingPolicies", propName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -122,6 +118,10 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 {
                     instanceRestartWaitDurationSeconds = reader.ReadValueAsString();
                 }
+                else if (string.Compare("CapacityReleaseAction", propName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    capacityReleaseAction = CapacityReleaseActionConverter.Deserialize(reader);
+                }
                 else
                 {
                     reader.SkipPropertyValue();
@@ -136,7 +136,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 loadMetrics: loadMetrics,
                 servicePlacementPolicies: servicePlacementPolicies,
                 defaultMoveCost: defaultMoveCost,
-                capacityReleaseAction: capacityReleaseAction,
                 scalingPolicies: scalingPolicies,
                 serviceDnsName: serviceDnsName,
                 serviceTags: serviceTags,
@@ -146,7 +145,8 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 minInstancePercentage: minInstancePercentage,
                 instanceCloseDelayDurationSeconds: instanceCloseDelayDurationSeconds,
                 instanceLifecycleDescription: instanceLifecycleDescription,
-                instanceRestartWaitDurationSeconds: instanceRestartWaitDurationSeconds);
+                instanceRestartWaitDurationSeconds: instanceRestartWaitDurationSeconds,
+                capacityReleaseAction: capacityReleaseAction);
         }
 
         /// <summary>
@@ -160,7 +160,6 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
             writer.WriteStartObject();
             writer.WriteProperty(obj.ServiceKind, "ServiceKind", ServiceKindConverter.Serialize);
             writer.WriteProperty(obj.DefaultMoveCost, "DefaultMoveCost", MoveCostConverter.Serialize);
-            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             if (obj.Flags != null)
             {
                 writer.WriteProperty(obj.Flags, "Flags", JsonWriterExtensions.WriteStringValue);
@@ -236,6 +235,7 @@ namespace Microsoft.ServiceFabric.Client.Http.Serialization
                 writer.WriteProperty(obj.InstanceRestartWaitDurationSeconds, "InstanceRestartWaitDurationSeconds", JsonWriterExtensions.WriteStringValue);
             }
 
+            writer.WriteProperty(obj.CapacityReleaseAction, "CapacityReleaseAction", CapacityReleaseActionConverter.Serialize);
             writer.WriteEndObject();
         }
     }

--- a/src/Client.Http/Client/Generated/IClusterClient.cs
+++ b/src/Client.Http/Client/Generated/IClusterClient.cs
@@ -773,6 +773,75 @@ namespace Microsoft.ServiceFabric.Client
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Gets the current capacity release level for the cluster.
+        /// </summary>
+        /// <remarks>
+        /// Gets the capacity release level currently applied to the Service Fabric cluster.
+        /// </remarks>
+        /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.</param>
+        /// <param name ="cancellationToken">Cancels the client-side operation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation.
+        /// </returns>
+        /// <exception cref="InvalidCredentialsException">Thrown when invalid credentials are used while making request to cluster.</exception>
+        /// <exception cref="ServiceFabricRequestException">Thrown when request to Service Fabric cluster failed due to an underlying issue such as network connectivity, DNS failure or timeout.</exception>
+        /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
+        Task<CapacityReleaseLevelResult> GetCapacityReleaseLevelAsync(
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Sets the capacity release level for the cluster.
+        /// </summary>
+        /// <remarks>
+        /// Sets the capacity release level applied to the Service Fabric cluster.
+        /// </remarks>
+        /// <param name ="level">The capacity release level to set for the cluster. Possible values include: 'None', 'Minor',
+        /// 'Major'</param>
+        /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.</param>
+        /// <param name ="cancellationToken">Cancels the client-side operation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation.
+        /// </returns>
+        /// <exception cref="InvalidCredentialsException">Thrown when invalid credentials are used while making request to cluster.</exception>
+        /// <exception cref="ServiceFabricRequestException">Thrown when request to Service Fabric cluster failed due to an underlying issue such as network connectivity, DNS failure or timeout.</exception>
+        /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
+        Task SetCapacityReleaseLevelAsync(
+            CapacityReleaseLevel? level,
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Gets capacity release estimates for the cluster.
+        /// </summary>
+        /// <remarks>
+        /// Gets capacity release estimates for cluster metrics at the available capacity release levels.
+        /// 
+        /// Runtimes that do not yet include the Placement and Load Balancing implementation for this operation return an
+        /// OperationNotSupported error.
+        /// </remarks>
+        /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.</param>
+        /// <param name ="cancellationToken">Cancels the client-side operation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation.
+        /// </returns>
+        /// <exception cref="InvalidCredentialsException">Thrown when invalid credentials are used while making request to cluster.</exception>
+        /// <exception cref="ServiceFabricRequestException">Thrown when request to Service Fabric cluster failed due to an underlying issue such as network connectivity, DNS failure or timeout.</exception>
+        /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
+        Task<IEnumerable<CapacityReleaseEstimate>> GetCapacityReleaseEstimationAsync(
+            long? serverTimeout = 60,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Changes the verbosity of service placement health reporting.
         /// </summary>
         /// <remarks>

--- a/src/Client.Http/Client/Generated/IClusterClient.cs
+++ b/src/Client.Http/Client/Generated/IClusterClient.cs
@@ -824,6 +824,8 @@ namespace Microsoft.ServiceFabric.Client
         /// Reports projected used capacity relative to cluster total capacity for each cluster metric at each reported
         /// capacity release level.
         /// </remarks>
+        /// <param name ="continuationToken">The continuation token to obtain the next set of results.</param>
+        /// <param name ="maxResults">The maximum number of results to return. The value must be non-negative.</param>
         /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.</param>
@@ -836,6 +838,8 @@ namespace Microsoft.ServiceFabric.Client
         /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
         /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
         Task<CapacityReleaseEstimationResult> GetCapacityReleaseEstimationAsync(
+            ContinuationToken continuationToken = default(ContinuationToken),
+            long? maxResults = 0,
             long? serverTimeout = 60,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Client.Http/Client/Generated/IClusterClient.cs
+++ b/src/Client.Http/Client/Generated/IClusterClient.cs
@@ -818,13 +818,11 @@ namespace Microsoft.ServiceFabric.Client
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Gets capacity release estimates for the cluster.
+        /// Gets projected used capacity relative to cluster total capacity for each metric at each capacity release level.
         /// </summary>
         /// <remarks>
-        /// Gets capacity release estimates for cluster metrics at the available capacity release levels.
-        /// 
-        /// Runtimes that do not yet include the Placement and Load Balancing implementation for this operation return an
-        /// OperationNotSupported error.
+        /// Reports projected used capacity relative to cluster total capacity for each cluster metric at each reported
+        /// capacity release level.
         /// </remarks>
         /// <param name ="serverTimeout">The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
@@ -837,7 +835,7 @@ namespace Microsoft.ServiceFabric.Client
         /// <exception cref="ServiceFabricRequestException">Thrown when request to Service Fabric cluster failed due to an underlying issue such as network connectivity, DNS failure or timeout.</exception>
         /// <exception cref="ServiceFabricException">Thrown when the requested operation failed at server. Exception contains Error code <see cref="FabricError.ErrorCode"/>, message indicating the failure. It also contains a flag wether the exception is transient or not, client operations can be retried if its transient.</exception>
         /// <exception cref="OperationCanceledException">Thrown when cancellation is requested for the cancellation token.</exception>
-        Task<IEnumerable<CapacityReleaseEstimate>> GetCapacityReleaseEstimationAsync(
+        Task<CapacityReleaseEstimationResult> GetCapacityReleaseEstimationAsync(
             long? serverTimeout = 60,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Client.Http/Common/Generated/CapacityReleaseAction.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseAction.cs
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for CapacityReleaseAction.
+    /// </summary>
+    public enum CapacityReleaseAction
+    {
+        /// <summary>
+        /// Capacity release does not change the service target.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Configures minor capacity release to target the service minimum and major capacity release to target zero.
+        /// </summary>
+        DropToZero,
+
+        /// <summary>
+        /// Configures minor capacity release to leave the service target unchanged and major capacity release to target the
+        /// service minimum.
+        /// </summary>
+        DropToMin,
+    }
+}

--- a/src/Client.Http/Common/Generated/CapacityReleaseEstimate.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseEstimate.cs
@@ -9,21 +9,24 @@ namespace Microsoft.ServiceFabric.Common
     using System.Collections.Generic;
 
     /// <summary>
-    /// An estimate of the capacity available at a capacity release level for a cluster metric.
+    /// An estimate of projected used capacity relative to cluster total capacity for a cluster metric under a capacity
+    /// release scenario.
     /// </summary>
     public partial class CapacityReleaseEstimate
     {
         /// <summary>
         /// Initializes a new instance of the CapacityReleaseEstimate class.
         /// </summary>
-        /// <param name="level">The capacity release level represented by this estimate. Possible values include: 'None',
-        /// 'Minor', 'Major'
+        /// <param name="level">The capacity release scenario whose projected impact this estimate represents. Possible values
+        /// include: 'None', 'Minor', 'Major'
         /// 
         /// The level of capacity release applied to the cluster.
         /// </param>
-        /// <param name="metricName">The name of the cluster metric.</param>
-        /// <param name="usedCapacity">The capacity currently used for the metric.</param>
-        /// <param name="totalCapacity">The total capacity available for the metric.</param>
+        /// <param name="metricName">The cluster metric being projected.</param>
+        /// <param name="usedCapacity">The projected used capacity for the metric if the capacity release level were
+        /// applied.</param>
+        /// <param name="totalCapacity">The cluster total capacity for the metric. This value is not projected and does not
+        /// depend on the capacity release level.</param>
         public CapacityReleaseEstimate(
             CapacityReleaseLevel? level,
             string metricName,
@@ -41,24 +44,26 @@ namespace Microsoft.ServiceFabric.Common
         }
 
         /// <summary>
-        /// Gets the capacity release level represented by this estimate. Possible values include: 'None', 'Minor', 'Major'
+        /// Gets the capacity release scenario whose projected impact this estimate represents. Possible values include:
+        /// 'None', 'Minor', 'Major'
         /// 
         /// The level of capacity release applied to the cluster.
         /// </summary>
         public CapacityReleaseLevel? Level { get; }
 
         /// <summary>
-        /// Gets the name of the cluster metric.
+        /// Gets the cluster metric being projected.
         /// </summary>
         public string MetricName { get; }
 
         /// <summary>
-        /// Gets the capacity currently used for the metric.
+        /// Gets the projected used capacity for the metric if the capacity release level were applied.
         /// </summary>
         public long? UsedCapacity { get; }
 
         /// <summary>
-        /// Gets the total capacity available for the metric.
+        /// Gets the cluster total capacity for the metric. This value is not projected and does not depend on the capacity
+        /// release level.
         /// </summary>
         public long? TotalCapacity { get; }
     }

--- a/src/Client.Http/Common/Generated/CapacityReleaseEstimate.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseEstimate.cs
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An estimate of the capacity available at a capacity release level for a cluster metric.
+    /// </summary>
+    public partial class CapacityReleaseEstimate
+    {
+        /// <summary>
+        /// Initializes a new instance of the CapacityReleaseEstimate class.
+        /// </summary>
+        /// <param name="level">The capacity release level represented by this estimate. Possible values include: 'None',
+        /// 'Minor', 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </param>
+        /// <param name="metricName">The name of the cluster metric.</param>
+        /// <param name="usedCapacity">The capacity currently used for the metric.</param>
+        /// <param name="totalCapacity">The total capacity available for the metric.</param>
+        public CapacityReleaseEstimate(
+            CapacityReleaseLevel? level,
+            string metricName,
+            long? usedCapacity,
+            long? totalCapacity)
+        {
+            level.ThrowIfNull(nameof(level));
+            metricName.ThrowIfNull(nameof(metricName));
+            usedCapacity.ThrowIfNull(nameof(usedCapacity));
+            totalCapacity.ThrowIfNull(nameof(totalCapacity));
+            this.Level = level;
+            this.MetricName = metricName;
+            this.UsedCapacity = usedCapacity;
+            this.TotalCapacity = totalCapacity;
+        }
+
+        /// <summary>
+        /// Gets the capacity release level represented by this estimate. Possible values include: 'None', 'Minor', 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </summary>
+        public CapacityReleaseLevel? Level { get; }
+
+        /// <summary>
+        /// Gets the name of the cluster metric.
+        /// </summary>
+        public string MetricName { get; }
+
+        /// <summary>
+        /// Gets the capacity currently used for the metric.
+        /// </summary>
+        public long? UsedCapacity { get; }
+
+        /// <summary>
+        /// Gets the total capacity available for the metric.
+        /// </summary>
+        public long? TotalCapacity { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/CapacityReleaseEstimationResult.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseEstimationResult.cs
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The capacity release estimates and the recommended capacity release level based on those projections.
+    /// </summary>
+    public partial class CapacityReleaseEstimationResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the CapacityReleaseEstimationResult class.
+        /// </summary>
+        /// <param name="items">The estimates reporting projected used capacity relative to cluster total capacity for each
+        /// cluster metric at each reported capacity release level.</param>
+        /// <param name="recommendedLevel">The recommended capacity release level based on the projections. Possible values
+        /// include: 'None', 'Minor', 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </param>
+        public CapacityReleaseEstimationResult(
+            IEnumerable<CapacityReleaseEstimate> items,
+            CapacityReleaseLevel? recommendedLevel)
+        {
+            items.ThrowIfNull(nameof(items));
+            recommendedLevel.ThrowIfNull(nameof(recommendedLevel));
+            this.Items = items;
+            this.RecommendedLevel = recommendedLevel;
+        }
+
+        /// <summary>
+        /// Gets the estimates reporting projected used capacity relative to cluster total capacity for each cluster metric at
+        /// each reported capacity release level.
+        /// </summary>
+        public IEnumerable<CapacityReleaseEstimate> Items { get; }
+
+        /// <summary>
+        /// Gets the recommended capacity release level based on the projections. Possible values include: 'None', 'Minor',
+        /// 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </summary>
+        public CapacityReleaseLevel? RecommendedLevel { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/CapacityReleaseEstimationResult.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseEstimationResult.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ServiceFabric.Common
     using System.Collections.Generic;
 
     /// <summary>
-    /// The capacity release estimates and the recommended capacity release level based on those projections.
+    /// A page of capacity release estimates.
     /// </summary>
     public partial class CapacityReleaseEstimationResult
     {
@@ -18,19 +18,14 @@ namespace Microsoft.ServiceFabric.Common
         /// </summary>
         /// <param name="items">The estimates reporting projected used capacity relative to cluster total capacity for each
         /// cluster metric at each reported capacity release level.</param>
-        /// <param name="recommendedLevel">The recommended capacity release level based on the projections. Possible values
-        /// include: 'None', 'Minor', 'Major'
-        /// 
-        /// The level of capacity release applied to the cluster.
-        /// </param>
+        /// <param name="continuationToken">The continuation token for the next page of results.</param>
         public CapacityReleaseEstimationResult(
             IEnumerable<CapacityReleaseEstimate> items,
-            CapacityReleaseLevel? recommendedLevel)
+            ContinuationToken continuationToken = default(ContinuationToken))
         {
             items.ThrowIfNull(nameof(items));
-            recommendedLevel.ThrowIfNull(nameof(recommendedLevel));
             this.Items = items;
-            this.RecommendedLevel = recommendedLevel;
+            this.ContinuationToken = continuationToken;
         }
 
         /// <summary>
@@ -40,11 +35,8 @@ namespace Microsoft.ServiceFabric.Common
         public IEnumerable<CapacityReleaseEstimate> Items { get; }
 
         /// <summary>
-        /// Gets the recommended capacity release level based on the projections. Possible values include: 'None', 'Minor',
-        /// 'Major'
-        /// 
-        /// The level of capacity release applied to the cluster.
+        /// Gets the continuation token for the next page of results.
         /// </summary>
-        public CapacityReleaseLevel? RecommendedLevel { get; }
+        public ContinuationToken ContinuationToken { get; }
     }
 }

--- a/src/Client.Http/Common/Generated/CapacityReleaseLevel.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseLevel.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    /// <summary>
+    /// Defines values for CapacityReleaseLevel.
+    /// </summary>
+    public enum CapacityReleaseLevel
+    {
+        /// <summary>
+        /// Indicates no capacity release.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Indicates minor capacity release.
+        /// </summary>
+        Minor,
+
+        /// <summary>
+        /// Indicates major capacity release.
+        /// </summary>
+        Major,
+    }
+}

--- a/src/Client.Http/Common/Generated/CapacityReleaseLevelResult.cs
+++ b/src/Client.Http/Common/Generated/CapacityReleaseLevelResult.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The current capacity release level for the cluster.
+    /// </summary>
+    public partial class CapacityReleaseLevelResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the CapacityReleaseLevelResult class.
+        /// </summary>
+        /// <param name="level">The current capacity release level. Possible values include: 'None', 'Minor', 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </param>
+        public CapacityReleaseLevelResult(
+            CapacityReleaseLevel? level)
+        {
+            level.ThrowIfNull(nameof(level));
+            this.Level = level;
+        }
+
+        /// <summary>
+        /// Gets the current capacity release level. Possible values include: 'None', 'Minor', 'Major'
+        /// 
+        /// The level of capacity release applied to the cluster.
+        /// </summary>
+        public CapacityReleaseLevel? Level { get; }
+    }
+}

--- a/src/Client.Http/Common/Generated/ServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceDescription.cs
@@ -36,6 +36,8 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -59,6 +61,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
@@ -80,6 +83,7 @@ namespace Microsoft.ServiceFabric.Common
             this.ServicePlacementPolicies = servicePlacementPolicies;
             this.DefaultMoveCost = defaultMoveCost;
             this.IsDefaultMoveCostSpecified = isDefaultMoveCostSpecified;
+            this.CapacityReleaseAction = capacityReleaseAction;
             this.ServicePackageActivationMode = servicePackageActivationMode;
             this.ServiceDnsName = serviceDnsName;
             this.ScalingPolicies = scalingPolicies;
@@ -145,6 +149,12 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets indicates if the DefaultMoveCost property is specified.
         /// </summary>
         public bool? IsDefaultMoveCostSpecified { get; }
+
+        /// <summary>
+        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
+        /// 'DropToZero', 'DropToMin'
+        /// </summary>
+        public CapacityReleaseAction? CapacityReleaseAction { get; }
 
         /// <summary>
         /// Gets the activation mode of service package to be used for a service. Possible values include: 'SharedProcess',

--- a/src/Client.Http/Common/Generated/ServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceDescription.cs
@@ -36,8 +36,6 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -48,6 +46,8 @@ namespace Microsoft.ServiceFabric.Common
         /// Service Fabric cluster.</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         protected ServiceDescription(
             ServiceName serviceName,
             string serviceTypeName,
@@ -61,11 +61,11 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
-            ServiceTags serviceTags = default(ServiceTags))
+            ServiceTags serviceTags = default(ServiceTags),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
         {
             serviceName.ThrowIfNull(nameof(serviceName));
             serviceTypeName.ThrowIfNull(nameof(serviceTypeName));
@@ -83,11 +83,11 @@ namespace Microsoft.ServiceFabric.Common
             this.ServicePlacementPolicies = servicePlacementPolicies;
             this.DefaultMoveCost = defaultMoveCost;
             this.IsDefaultMoveCostSpecified = isDefaultMoveCostSpecified;
-            this.CapacityReleaseAction = capacityReleaseAction;
             this.ServicePackageActivationMode = servicePackageActivationMode;
             this.ServiceDnsName = serviceDnsName;
             this.ScalingPolicies = scalingPolicies;
             this.ServiceTags = serviceTags;
+            this.CapacityReleaseAction = capacityReleaseAction;
         }
 
         /// <summary>
@@ -151,12 +151,6 @@ namespace Microsoft.ServiceFabric.Common
         public bool? IsDefaultMoveCostSpecified { get; }
 
         /// <summary>
-        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
-        /// 'DropToZero', 'DropToMin'
-        /// </summary>
-        public CapacityReleaseAction? CapacityReleaseAction { get; }
-
-        /// <summary>
         /// Gets the activation mode of service package to be used for a service. Possible values include: 'SharedProcess',
         /// 'ExclusiveProcess'
         /// 
@@ -179,6 +173,12 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets service tags collections for placement and running of the service.
         /// </summary>
         public ServiceTags ServiceTags { get; }
+
+        /// <summary>
+        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
+        /// 'DropToZero', 'DropToMin'
+        /// </summary>
+        public CapacityReleaseAction? CapacityReleaseAction { get; }
 
         /// <summary>
         /// Gets the kind of service (Stateless or Stateful).

--- a/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
@@ -45,6 +45,7 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
+        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -58,6 +59,8 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
@@ -70,6 +73,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
@@ -83,6 +87,7 @@ namespace Microsoft.ServiceFabric.Common
             this.LoadMetrics = loadMetrics;
             this.ServicePlacementPolicies = servicePlacementPolicies;
             this.DefaultMoveCost = defaultMoveCost;
+            this.CapacityReleaseAction = capacityReleaseAction;
             this.ScalingPolicies = scalingPolicies;
             this.ServiceDnsName = serviceDnsName;
             this.ServiceTags = serviceTags;
@@ -149,6 +154,12 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </summary>
         public MoveCost? DefaultMoveCost { get; }
+
+        /// <summary>
+        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
+        /// 'DropToZero', 'DropToMin'
+        /// </summary>
+        public CapacityReleaseAction? CapacityReleaseAction { get; }
 
         /// <summary>
         /// Gets scaling policies for this service.

--- a/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/ServiceUpdateDescription.cs
@@ -45,7 +45,6 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
-        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -59,12 +58,12 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
         /// <param name="repartitionDescription">The repartition description as an object.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         protected ServiceUpdateDescription(
             ServiceKind? serviceKind,
             string flags = default(string),
@@ -73,11 +72,11 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
-            RepartitionSchemeDescription repartitionDescription = default(RepartitionSchemeDescription))
+            RepartitionSchemeDescription repartitionDescription = default(RepartitionSchemeDescription),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
         {
             serviceKind.ThrowIfNull(nameof(serviceKind));
             this.ServiceKind = serviceKind;
@@ -87,11 +86,11 @@ namespace Microsoft.ServiceFabric.Common
             this.LoadMetrics = loadMetrics;
             this.ServicePlacementPolicies = servicePlacementPolicies;
             this.DefaultMoveCost = defaultMoveCost;
-            this.CapacityReleaseAction = capacityReleaseAction;
             this.ScalingPolicies = scalingPolicies;
             this.ServiceDnsName = serviceDnsName;
             this.ServiceTags = serviceTags;
             this.RepartitionDescription = repartitionDescription;
+            this.CapacityReleaseAction = capacityReleaseAction;
         }
 
         /// <summary>
@@ -156,12 +155,6 @@ namespace Microsoft.ServiceFabric.Common
         public MoveCost? DefaultMoveCost { get; }
 
         /// <summary>
-        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
-        /// 'DropToZero', 'DropToMin'
-        /// </summary>
-        public CapacityReleaseAction? CapacityReleaseAction { get; }
-
-        /// <summary>
         /// Gets scaling policies for this service.
         /// </summary>
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; }
@@ -180,6 +173,12 @@ namespace Microsoft.ServiceFabric.Common
         /// Gets the repartition description as an object.
         /// </summary>
         public RepartitionSchemeDescription RepartitionDescription { get; }
+
+        /// <summary>
+        /// Gets specifies the service target policy configured for capacity release. Possible values include: 'None',
+        /// 'DropToZero', 'DropToMin'
+        /// </summary>
+        public CapacityReleaseAction? CapacityReleaseAction { get; }
 
         /// <summary>
         /// Gets the kind of service (Stateless or Stateful).

--- a/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
@@ -39,6 +39,8 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -101,6 +103,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
@@ -128,6 +131,7 @@ namespace Microsoft.ServiceFabric.Common
                 servicePlacementPolicies,
                 defaultMoveCost,
                 isDefaultMoveCostSpecified,
+                capacityReleaseAction,
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,

--- a/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceDescription.cs
@@ -39,8 +39,6 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -88,6 +86,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InitiallyDisabled - The service is created in a disabled state and must be
         /// explicitly enabled before any replicas or instances are placed. The value is 1.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         public StatefulServiceDescription(
             ServiceName serviceName,
             string serviceTypeName,
@@ -103,7 +103,6 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
@@ -117,7 +116,8 @@ namespace Microsoft.ServiceFabric.Common
             ReplicaLifecycleDescription replicaLifecycleDescription = default(ReplicaLifecycleDescription),
             int? auxiliaryReplicaCount = default(int?),
             ServiceSensitivityDescription serviceSensitivityDescription = default(ServiceSensitivityDescription),
-            int? serviceOptions = default(int?))
+            int? serviceOptions = default(int?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
             : base(
                 serviceName,
                 serviceTypeName,
@@ -131,11 +131,11 @@ namespace Microsoft.ServiceFabric.Common
                 servicePlacementPolicies,
                 defaultMoveCost,
                 isDefaultMoveCostSpecified,
-                capacityReleaseAction,
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,
-                serviceTags)
+                serviceTags,
+                capacityReleaseAction)
         {
             targetReplicaSetSize.ThrowIfNull(nameof(targetReplicaSetSize));
             minReplicaSetSize.ThrowIfNull(nameof(minReplicaSetSize));

--- a/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
@@ -44,6 +44,7 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
+        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -57,6 +58,8 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
@@ -86,6 +89,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
@@ -108,6 +112,7 @@ namespace Microsoft.ServiceFabric.Common
                 loadMetrics,
                 servicePlacementPolicies,
                 defaultMoveCost,
+                capacityReleaseAction,
                 scalingPolicies,
                 serviceDnsName,
                 serviceTags,

--- a/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatefulServiceUpdateDescription.cs
@@ -44,7 +44,6 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
-        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -58,8 +57,6 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
@@ -82,6 +79,8 @@ namespace Microsoft.ServiceFabric.Common
         /// <param name="auxiliaryReplicaCount">The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.</param>
         /// <param name="serviceSensitivityDescription">Defines default levels of replica sensitivity of this service.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         public StatefulServiceUpdateDescription(
             string flags = default(string),
             string placementConstraints = default(string),
@@ -89,7 +88,6 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
@@ -103,7 +101,8 @@ namespace Microsoft.ServiceFabric.Common
             bool? dropSourceReplicaOnMove = default(bool?),
             ReplicaLifecycleDescription replicaLifecycleDescription = default(ReplicaLifecycleDescription),
             int? auxiliaryReplicaCount = default(int?),
-            ServiceSensitivityDescription serviceSensitivityDescription = default(ServiceSensitivityDescription))
+            ServiceSensitivityDescription serviceSensitivityDescription = default(ServiceSensitivityDescription),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
             : base(
                 Common.ServiceKind.Stateful,
                 flags,
@@ -112,11 +111,11 @@ namespace Microsoft.ServiceFabric.Common
                 loadMetrics,
                 servicePlacementPolicies,
                 defaultMoveCost,
-                capacityReleaseAction,
                 scalingPolicies,
                 serviceDnsName,
                 serviceTags,
-                repartitionDescription)
+                repartitionDescription,
+                capacityReleaseAction)
         {
             targetReplicaSetSize?.ThrowIfLessThan("targetReplicaSetSize", 1);
             minReplicaSetSize?.ThrowIfLessThan("minReplicaSetSize", 1);

--- a/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
@@ -36,6 +36,8 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -113,6 +115,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
@@ -137,6 +140,7 @@ namespace Microsoft.ServiceFabric.Common
                 servicePlacementPolicies,
                 defaultMoveCost,
                 isDefaultMoveCostSpecified,
+                capacityReleaseAction,
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,

--- a/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceDescription.cs
@@ -36,8 +36,6 @@ namespace Microsoft.ServiceFabric.Common
         /// Specifies the move cost for the service.
         /// </param>
         /// <param name="isDefaultMoveCostSpecified">Indicates if the DefaultMoveCost property is specified.</param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="servicePackageActivationMode">The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
@@ -102,6 +100,8 @@ namespace Microsoft.ServiceFabric.Common
         /// - InitiallyDisabled - The service is created in a disabled state and must be
         /// explicitly enabled before any replicas or instances are placed. The value is 1.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         public StatelessServiceDescription(
             ServiceName serviceName,
             string serviceTypeName,
@@ -115,7 +115,6 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
             bool? isDefaultMoveCostSpecified = default(bool?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             ServicePackageActivationMode? servicePackageActivationMode = default(ServicePackageActivationMode?),
             string serviceDnsName = default(string),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
@@ -126,7 +125,8 @@ namespace Microsoft.ServiceFabric.Common
             long? instanceCloseDelayDurationSeconds = default(long?),
             InstanceLifecycleDescription instanceLifecycleDescription = default(InstanceLifecycleDescription),
             long? instanceRestartWaitDurationSeconds = default(long?),
-            int? serviceOptions = default(int?))
+            int? serviceOptions = default(int?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
             : base(
                 serviceName,
                 serviceTypeName,
@@ -140,11 +140,11 @@ namespace Microsoft.ServiceFabric.Common
                 servicePlacementPolicies,
                 defaultMoveCost,
                 isDefaultMoveCostSpecified,
-                capacityReleaseAction,
                 servicePackageActivationMode,
                 serviceDnsName,
                 scalingPolicies,
-                serviceTags)
+                serviceTags,
+                capacityReleaseAction)
         {
             instanceCount.ThrowIfNull(nameof(instanceCount));
             instanceCount?.ThrowIfLessThan("instanceCount", -1);

--- a/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
@@ -44,6 +44,7 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
+        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -57,6 +58,8 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
@@ -104,6 +107,7 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
@@ -122,6 +126,7 @@ namespace Microsoft.ServiceFabric.Common
                 loadMetrics,
                 servicePlacementPolicies,
                 defaultMoveCost,
+                capacityReleaseAction,
                 scalingPolicies,
                 serviceDnsName,
                 serviceTags,

--- a/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
+++ b/src/Client.Http/Common/Generated/StatelessServiceUpdateDescription.cs
@@ -44,7 +44,6 @@ namespace Microsoft.ServiceFabric.Common
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
-        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </param>
         /// <param name="placementConstraints">The placement constraints as a string. Placement constraints are boolean
         /// expressions on node properties and allow for restricting a service to particular nodes based on the service
@@ -58,8 +57,6 @@ namespace Microsoft.ServiceFabric.Common
         /// 
         /// Specifies the move cost for the service.
         /// </param>
-        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         /// <param name="scalingPolicies">Scaling policies for this service.</param>
         /// <param name="serviceDnsName">The DNS name of the service.</param>
         /// <param name="serviceTags">Service tags collections for placement and running of the service.</param>
@@ -100,6 +97,8 @@ namespace Microsoft.ServiceFabric.Common
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </param>
+        /// <param name="capacityReleaseAction">Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'</param>
         public StatelessServiceUpdateDescription(
             string flags = default(string),
             string placementConstraints = default(string),
@@ -107,7 +106,6 @@ namespace Microsoft.ServiceFabric.Common
             IEnumerable<ServiceLoadMetricDescription> loadMetrics = default(IEnumerable<ServiceLoadMetricDescription>),
             IEnumerable<ServicePlacementPolicyDescription> servicePlacementPolicies = default(IEnumerable<ServicePlacementPolicyDescription>),
             MoveCost? defaultMoveCost = default(MoveCost?),
-            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?),
             IEnumerable<ScalingPolicyDescription> scalingPolicies = default(IEnumerable<ScalingPolicyDescription>),
             string serviceDnsName = default(string),
             ServiceTags serviceTags = default(ServiceTags),
@@ -117,7 +115,8 @@ namespace Microsoft.ServiceFabric.Common
             int? minInstancePercentage = default(int?),
             string instanceCloseDelayDurationSeconds = default(string),
             InstanceLifecycleDescription instanceLifecycleDescription = default(InstanceLifecycleDescription),
-            string instanceRestartWaitDurationSeconds = default(string))
+            string instanceRestartWaitDurationSeconds = default(string),
+            CapacityReleaseAction? capacityReleaseAction = default(CapacityReleaseAction?))
             : base(
                 Common.ServiceKind.Stateless,
                 flags,
@@ -126,11 +125,11 @@ namespace Microsoft.ServiceFabric.Common
                 loadMetrics,
                 servicePlacementPolicies,
                 defaultMoveCost,
-                capacityReleaseAction,
                 scalingPolicies,
                 serviceDnsName,
                 serviceTags,
-                repartitionDescription)
+                repartitionDescription,
+                capacityReleaseAction)
         {
             instanceCount?.ThrowIfLessThan("instanceCount", -1);
             this.InstanceCount = instanceCount;

--- a/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
+++ b/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Powershell.Http
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Management.Automation;
+    using Microsoft.ServiceFabric.Common;
+
+    /// <summary>
+    /// Gets capacity release estimates for the cluster.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "SFCapacityReleaseEstimation")]
+    public partial class GetCapacityReleaseEstimationCmdlet : CommonCmdletBase
+    {
+        /// <summary>
+        /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0)]
+        public long? ServerTimeout { get; set; }
+
+        /// <inheritdoc/>
+        protected override void ProcessRecordInternal()
+        {
+            var result = this.ServiceFabricClient.Cluster.GetCapacityReleaseEstimationAsync(
+                serverTimeout: this.ServerTimeout,
+                cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
+
+            if (result != null)
+            {
+                foreach (var item in result)
+                {
+                    this.WriteObject(this.FormatOutput(item));
+                }
+            }
+        }
+    }
+}

--- a/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
+++ b/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
@@ -17,17 +17,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
     public partial class GetCapacityReleaseEstimationCmdlet : CommonCmdletBase
     {
         /// <summary>
+        /// Gets or sets ContinuationToken. The continuation token to obtain the next set of results.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0)]
+        public ContinuationToken ContinuationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets MaxResults. The maximum number of results to return. The value must be non-negative.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 1)]
+        [ValidateRange(0, long.MaxValue)]
+        public long? MaxResults { get; set; }
+
+        /// <summary>
         /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 0)]
+        [Parameter(Mandatory = false, Position = 2)]
         public long? ServerTimeout { get; set; }
 
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
         {
             var result = this.ServiceFabricClient.Cluster.GetCapacityReleaseEstimationAsync(
+                continuationToken: this.ContinuationToken,
+                maxResults: this.MaxResults,
                 serverTimeout: this.ServerTimeout,
                 cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
 

--- a/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
+++ b/src/Powershell.Http/Generated/GetCapacityReleaseEstimationCmdlet.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
     using Microsoft.ServiceFabric.Common;
 
     /// <summary>
-    /// Gets capacity release estimates for the cluster.
+    /// Gets projected used capacity relative to cluster total capacity for each metric at each capacity release level.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "SFCapacityReleaseEstimation")]
     public partial class GetCapacityReleaseEstimationCmdlet : CommonCmdletBase
@@ -33,11 +33,14 @@ namespace Microsoft.ServiceFabric.Powershell.Http
 
             if (result != null)
             {
-                foreach (var item in result)
-                {
-                    this.WriteObject(this.FormatOutput(item));
-                }
+                this.WriteObject(this.FormatOutput(result));
             }
+        }
+
+        /// <inheritdoc/>
+        protected override object FormatOutput(object output)
+        {
+            return output;
         }
     }
 }

--- a/src/Powershell.Http/Generated/GetCapacityReleaseLevelCmdlet.cs
+++ b/src/Powershell.Http/Generated/GetCapacityReleaseLevelCmdlet.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Powershell.Http
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Management.Automation;
+    using Microsoft.ServiceFabric.Common;
+
+    /// <summary>
+    /// Gets the current capacity release level for the cluster.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "SFCapacityReleaseLevel")]
+    public partial class GetCapacityReleaseLevelCmdlet : CommonCmdletBase
+    {
+        /// <summary>
+        /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0)]
+        public long? ServerTimeout { get; set; }
+
+        /// <inheritdoc/>
+        protected override void ProcessRecordInternal()
+        {
+            var result = this.ServiceFabricClient.Cluster.GetCapacityReleaseLevelAsync(
+                serverTimeout: this.ServerTimeout,
+                cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
+
+            if (result != null)
+            {
+                this.WriteObject(this.FormatOutput(result));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override object FormatOutput(object output)
+        {
+            return output;
+        }
+    }
+}

--- a/src/Powershell.Http/Generated/NewServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/NewServiceCmdlet.cs
@@ -196,43 +196,36 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public bool? IsDefaultMoveCostSpecified { get; set; }
 
         /// <summary>
-        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'
-        /// </summary>
-        [Parameter(Mandatory = false, Position = 21)]
-        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
-
-        /// <summary>
         /// Gets or sets ServicePackageActivationMode. The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
         /// The activation mode of service package to be used for a Service Fabric service. This is specified at the time of
         /// creating the Service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 22)]
+        [Parameter(Mandatory = false, Position = 21)]
         public ServicePackageActivationMode? ServicePackageActivationMode { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceDnsName. The DNS name of the service. It requires the DNS system service to be enabled in
         /// Service Fabric cluster.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 23)]
+        [Parameter(Mandatory = false, Position = 22)]
         public string ServiceDnsName { get; set; }
 
         /// <summary>
         /// Gets or sets ScalingPolicies. Scaling policies for this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24)]
+        [Parameter(Mandatory = false, Position = 23)]
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25)]
+        [Parameter(Mandatory = false, Position = 24)]
         public IEnumerable<string> TagsRequiredToPlace { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26)]
+        [Parameter(Mandatory = false, Position = 25)]
         public IEnumerable<string> TagsRequiredToRun { get; set; }
 
         /// <summary>
@@ -249,48 +242,48 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - ServicePlacementTimeLimit - Indicates the ServicePlacementTimeLimit property is set. The value is 8.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 16.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateful_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? Flags { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaRestartWaitDurationSeconds. The duration, in seconds, between when a replica goes down and when
         /// a new replica is created.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? ReplicaRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets QuorumLossWaitDurationSeconds. The maximum duration, in seconds, for which a partition is allowed to
         /// be in a state of quorum loss.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? QuorumLossWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets StandByReplicaKeepDurationSeconds. Defines how long StandBy replicas should be maintained before being
         /// removed.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? StandByReplicaKeepDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementTimeLimitSeconds. The duration for which replicas can stay InBuild before reporting
         /// that build is stuck.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? ServicePlacementTimeLimitSeconds { get; set; }
 
         /// <summary>
@@ -298,34 +291,34 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; set; }
 
         /// <summary>
         /// Gets or sets AuxiliaryReplicaCount. The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public int? AuxiliaryReplicaCount { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceSensitivityDescription. Defines default levels of replica sensitivity of this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public ServiceSensitivityDescription ServiceSensitivityDescription { get; set; }
 
         /// <summary>
@@ -337,12 +330,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - InitiallyDisabled - The service is created in a disabled state and must be
         /// explicitly enabled before any replicas or instances are placed. The value is 1.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateful_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? ServiceOptions { get; set; }
 
         /// <summary>
@@ -352,9 +345,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of
         /// nodes on which the instances are allowed to be placed according to the placement constraints on the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? MinInstanceCount { get; set; }
 
         /// <summary>
@@ -365,9 +358,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// number of nodes on which the instances are allowed to be placed according to the placement constraints on the
         /// service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? MinInstancePercentage { get; set; }
 
         /// <summary>
@@ -386,18 +379,18 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, the default value of InstanceCloseDelayDuration is 0, which indicates that there won't be any delay or
         /// removal of the endpoint prior to closing the instance.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public long? InstanceCloseDelayDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceLifecycleDescription. Defines how instances of this service will behave during their
         /// lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public InstanceLifecycleDescription InstanceLifecycleDescription { get; set; }
 
         /// <summary>
@@ -408,9 +401,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public long? InstanceRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
@@ -418,8 +411,15 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 42)]
+        [Parameter(Mandatory = false, Position = 41)]
         public long? ServerTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 42)]
+        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
 
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
@@ -466,7 +466,6 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
                     isDefaultMoveCostSpecified: this.IsDefaultMoveCostSpecified,
-                    capacityReleaseAction: this.CapacityReleaseAction,
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,
@@ -480,7 +479,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     replicaLifecycleDescription: this.ReplicaLifecycleDescription,
                     auxiliaryReplicaCount: this.AuxiliaryReplicaCount,
                     serviceSensitivityDescription: this.ServiceSensitivityDescription,
-                    serviceOptions: this.ServiceOptions);
+                    serviceOptions: this.ServiceOptions,
+                    capacityReleaseAction: this.CapacityReleaseAction);
             }
             else if (this.Stateless.IsPresent)
             {
@@ -497,7 +497,6 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
                     isDefaultMoveCostSpecified: this.IsDefaultMoveCostSpecified,
-                    capacityReleaseAction: this.CapacityReleaseAction,
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,
@@ -508,7 +507,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     instanceCloseDelayDurationSeconds: this.InstanceCloseDelayDurationSeconds,
                     instanceLifecycleDescription: this.InstanceLifecycleDescription,
                     instanceRestartWaitDurationSeconds: this.InstanceRestartWaitDurationSeconds,
-                    serviceOptions: this.ServiceOptions);
+                    serviceOptions: this.ServiceOptions,
+                    capacityReleaseAction: this.CapacityReleaseAction);
             }
 
             this.ServiceFabricClient.Services.CreateServiceAsync(

--- a/src/Powershell.Http/Generated/NewServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/NewServiceCmdlet.cs
@@ -196,36 +196,43 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public bool? IsDefaultMoveCostSpecified { get; set; }
 
         /// <summary>
+        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 21)]
+        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
+
+        /// <summary>
         /// Gets or sets ServicePackageActivationMode. The activation mode of service package to be used for a service.
         /// Possible values include: 'SharedProcess', 'ExclusiveProcess'
         /// 
         /// The activation mode of service package to be used for a Service Fabric service. This is specified at the time of
         /// creating the Service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 21)]
+        [Parameter(Mandatory = false, Position = 22)]
         public ServicePackageActivationMode? ServicePackageActivationMode { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceDnsName. The DNS name of the service. It requires the DNS system service to be enabled in
         /// Service Fabric cluster.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 22)]
+        [Parameter(Mandatory = false, Position = 23)]
         public string ServiceDnsName { get; set; }
 
         /// <summary>
         /// Gets or sets ScalingPolicies. Scaling policies for this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 23)]
+        [Parameter(Mandatory = false, Position = 24)]
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24)]
+        [Parameter(Mandatory = false, Position = 25)]
         public IEnumerable<string> TagsRequiredToPlace { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25)]
+        [Parameter(Mandatory = false, Position = 26)]
         public IEnumerable<string> TagsRequiredToRun { get; set; }
 
         /// <summary>
@@ -242,48 +249,48 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - ServicePlacementTimeLimit - Indicates the ServicePlacementTimeLimit property is set. The value is 8.
         /// - DropSourceReplicaOnMove - Indicates the DropSourceReplicaOnMove property is set. The value is 16.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_UniformInt64Range__Stateful_")]
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? Flags { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaRestartWaitDurationSeconds. The duration, in seconds, between when a replica goes down and when
         /// a new replica is created.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? ReplicaRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets QuorumLossWaitDurationSeconds. The maximum duration, in seconds, for which a partition is allowed to
         /// be in a state of quorum loss.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? QuorumLossWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets StandByReplicaKeepDurationSeconds. Defines how long StandBy replicas should be maintained before being
         /// removed.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? StandByReplicaKeepDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementTimeLimitSeconds. The duration for which replicas can stay InBuild before reporting
         /// that build is stuck.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public long? ServicePlacementTimeLimitSeconds { get; set; }
 
         /// <summary>
@@ -291,34 +298,34 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 32, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; set; }
 
         /// <summary>
         /// Gets or sets AuxiliaryReplicaCount. The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 33, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public int? AuxiliaryReplicaCount { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceSensitivityDescription. Defines default levels of replica sensitivity of this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 34, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateful_")]
         public ServiceSensitivityDescription ServiceSensitivityDescription { get; set; }
 
         /// <summary>
@@ -330,12 +337,12 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - InitiallyDisabled - The service is created in a disabled state and must be
         /// explicitly enabled before any replicas or instances are placed. The value is 1.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateful_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateful_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 35, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateful_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateful_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? ServiceOptions { get; set; }
 
         /// <summary>
@@ -345,9 +352,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of
         /// nodes on which the instances are allowed to be placed according to the placement constraints on the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 36, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? MinInstanceCount { get; set; }
 
         /// <summary>
@@ -358,9 +365,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// number of nodes on which the instances are allowed to be placed according to the placement constraints on the
         /// service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 37, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public int? MinInstancePercentage { get; set; }
 
         /// <summary>
@@ -379,18 +386,18 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, the default value of InstanceCloseDelayDuration is 0, which indicates that there won't be any delay or
         /// removal of the endpoint prior to closing the instance.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 38, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public long? InstanceCloseDelayDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceLifecycleDescription. Defines how instances of this service will behave during their
         /// lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 39, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public InstanceLifecycleDescription InstanceLifecycleDescription { get; set; }
 
         /// <summary>
@@ -401,9 +408,9 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Named__Stateless_")]
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_Singleton__Stateless_")]
-        [Parameter(Mandatory = false, Position = 40, ParameterSetName = "_UniformInt64Range__Stateless_")]
+        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_Singleton__Stateless_")]
+        [Parameter(Mandatory = false, Position = 41, ParameterSetName = "_UniformInt64Range__Stateless_")]
         public long? InstanceRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
@@ -411,7 +418,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 41)]
+        [Parameter(Mandatory = false, Position = 42)]
         public long? ServerTimeout { get; set; }
 
         /// <inheritdoc/>
@@ -459,6 +466,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
                     isDefaultMoveCostSpecified: this.IsDefaultMoveCostSpecified,
+                    capacityReleaseAction: this.CapacityReleaseAction,
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,
@@ -489,6 +497,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
                     isDefaultMoveCostSpecified: this.IsDefaultMoveCostSpecified,
+                    capacityReleaseAction: this.CapacityReleaseAction,
                     servicePackageActivationMode: this.ServicePackageActivationMode,
                     serviceDnsName: this.ServiceDnsName,
                     scalingPolicies: this.ScalingPolicies,

--- a/src/Powershell.Http/Generated/SetCapacityReleaseLevelCmdlet.cs
+++ b/src/Powershell.Http/Generated/SetCapacityReleaseLevelCmdlet.cs
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.ServiceFabric.Powershell.Http
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Management.Automation;
+    using Microsoft.ServiceFabric.Common;
+
+    /// <summary>
+    /// Sets the capacity release level for the cluster.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Set, "SFCapacityReleaseLevel")]
+    public partial class SetCapacityReleaseLevelCmdlet : CommonCmdletBase
+    {
+        /// <summary>
+        /// Gets or sets Level. The capacity release level to set for the cluster. Possible values include: 'None', 'Minor',
+        /// 'Major'
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public CapacityReleaseLevel? Level { get; set; }
+
+        /// <summary>
+        /// Gets or sets ServerTimeout. The server timeout for performing the operation in seconds. This timeout specifies the
+        /// time duration that the client is willing to wait for the requested operation to complete. The default value for
+        /// this parameter is 60 seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 1)]
+        public long? ServerTimeout { get; set; }
+
+        /// <inheritdoc/>
+        protected override void ProcessRecordInternal()
+        {
+            this.ServiceFabricClient.Cluster.SetCapacityReleaseLevelAsync(
+                level: this.Level,
+                serverTimeout: this.ServerTimeout,
+                cancellationToken: this.CancellationToken).GetAwaiter().GetResult();
+
+            Console.WriteLine("Success!");
+        }
+    }
+}

--- a/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
@@ -116,86 +116,79 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public MoveCost? DefaultMoveCost { get; set; }
 
         /// <summary>
-        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
-        /// values include: 'None', 'DropToZero', 'DropToMin'
-        /// </summary>
-        [Parameter(Mandatory = false, Position = 9)]
-        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
-
-        /// <summary>
         /// Gets or sets ScalingPolicies. Scaling policies for this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 10)]
+        [Parameter(Mandatory = false, Position = 9)]
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceDnsName. The DNS name of the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 11)]
+        [Parameter(Mandatory = false, Position = 10)]
         public string ServiceDnsName { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 12)]
+        [Parameter(Mandatory = false, Position = 11)]
         public IEnumerable<string> TagsRequiredToPlace { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 13)]
+        [Parameter(Mandatory = false, Position = 12)]
         public IEnumerable<string> TagsRequiredToRun { get; set; }
 
         /// <summary>
         /// Gets or sets NamesToAdd. Dynamic array for the names of the partitions to add.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateless_")]
         public IEnumerable<string> NamesToAdd { get; set; }
 
         /// <summary>
         /// Gets or sets NamesToRemove. Dynamic array for the names of the partitions to remove.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateless_")]
         public IEnumerable<string> NamesToRemove { get; set; }
 
         /// <summary>
         /// Gets or sets TargetReplicaSetSize. The target replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateful_")]
         public int? TargetReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets MinReplicaSetSize. The minimum replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Named__Stateful_")]
         public int? MinReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaRestartWaitDurationSeconds. The duration, in seconds, between when a replica goes down and when
         /// a new replica is created.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Named__Stateful_")]
         public string ReplicaRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets QuorumLossWaitDurationSeconds. The maximum duration, in seconds, for which a partition is allowed to
         /// be in a state of quorum loss.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Named__Stateful_")]
         public string QuorumLossWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets StandByReplicaKeepDurationSeconds. The definition on how long StandBy replicas should be maintained
         /// before being removed.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Named__Stateful_")]
         public string StandByReplicaKeepDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementTimeLimitSeconds. The duration for which replicas can stay InBuild before reporting
         /// that build is stuck.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Named__Stateful_")]
         public string ServicePlacementTimeLimitSeconds { get; set; }
 
         /// <summary>
@@ -203,32 +196,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Named__Stateful_")]
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Named__Stateful_")]
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; set; }
 
         /// <summary>
         /// Gets or sets AuxiliaryReplicaCount. The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Named__Stateful_")]
         public int? AuxiliaryReplicaCount { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceSensitivityDescription. Defines default levels of replica sensitivity of this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Named__Stateful_")]
         public ServiceSensitivityDescription ServiceSensitivityDescription { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceCount. The instance count.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Named__Stateless_")]
         public int? InstanceCount { get; set; }
 
         /// <summary>
@@ -238,7 +231,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of
         /// nodes on which the instances are allowed to be placed according to the placement constraints on the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstanceCount { get; set; }
 
         /// <summary>
@@ -249,7 +242,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// number of nodes on which the instances are allowed to be placed according to the placement constraints on the
         /// service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstancePercentage { get; set; }
 
         /// <summary>
@@ -266,14 +259,14 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - Close existing connections after in-flight requests have completed.
         /// - Connect to a different instance of the service partition for future requests.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateless_")]
         public string InstanceCloseDelayDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceLifecycleDescription. Defines how instances of this service will behave during their
         /// lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateless_")]
         public InstanceLifecycleDescription InstanceLifecycleDescription { get; set; }
 
         /// <summary>
@@ -284,7 +277,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateless_")]
         public string InstanceRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
@@ -292,8 +285,15 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 32)]
+        [Parameter(Mandatory = false, Position = 31)]
         public long? ServerTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 32)]
+        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
 
         /// <inheritdoc/>
         protected override void ProcessRecordInternal()
@@ -321,7 +321,6 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     loadMetrics: this.LoadMetrics,
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
-                    capacityReleaseAction: this.CapacityReleaseAction,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
                     serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
@@ -335,7 +334,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     dropSourceReplicaOnMove: this.DropSourceReplicaOnMove,
                     replicaLifecycleDescription: this.ReplicaLifecycleDescription,
                     auxiliaryReplicaCount: this.AuxiliaryReplicaCount,
-                    serviceSensitivityDescription: this.ServiceSensitivityDescription);
+                    serviceSensitivityDescription: this.ServiceSensitivityDescription,
+                    capacityReleaseAction: this.CapacityReleaseAction);
             }
             else if (this.Stateless.IsPresent)
             {
@@ -346,7 +346,6 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     loadMetrics: this.LoadMetrics,
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
-                    capacityReleaseAction: this.CapacityReleaseAction,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
                     serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
@@ -356,7 +355,8 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     minInstancePercentage: this.MinInstancePercentage,
                     instanceCloseDelayDurationSeconds: this.InstanceCloseDelayDurationSeconds,
                     instanceLifecycleDescription: this.InstanceLifecycleDescription,
-                    instanceRestartWaitDurationSeconds: this.InstanceRestartWaitDurationSeconds);
+                    instanceRestartWaitDurationSeconds: this.InstanceRestartWaitDurationSeconds,
+                    capacityReleaseAction: this.CapacityReleaseAction);
             }
 
             this.ServiceFabricClient.Services.UpdateServiceAsync(

--- a/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
+++ b/src/Powershell.Http/Generated/UpdateServiceCmdlet.cs
@@ -74,6 +74,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - ServiceDnsName - Indicates the ServiceDnsName property is set. The value is 131072.
         /// - ServiceTags TagsRequiredToPlace - Indicates the TagsRequiredToPlace property is set. The value is 1048576.
         /// - ServiceTags TagsRequiredToRun - Indicates the TagsRequiredToRun property is set. The value is 2097152.
+        /// - CapacityReleaseAction - Indicates the CapacityReleaseAction property is set. The value is 268435456.
         /// </summary>
         [Parameter(Mandatory = false, Position = 3)]
         public string Flags { get; set; }
@@ -115,79 +116,86 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         public MoveCost? DefaultMoveCost { get; set; }
 
         /// <summary>
-        /// Gets or sets ScalingPolicies. Scaling policies for this service.
+        /// Gets or sets CapacityReleaseAction. Specifies the service target policy configured for capacity release. Possible
+        /// values include: 'None', 'DropToZero', 'DropToMin'
         /// </summary>
         [Parameter(Mandatory = false, Position = 9)]
+        public CapacityReleaseAction? CapacityReleaseAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets ScalingPolicies. Scaling policies for this service.
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 10)]
         public IEnumerable<ScalingPolicyDescription> ScalingPolicies { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceDnsName. The DNS name of the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 10)]
+        [Parameter(Mandatory = false, Position = 11)]
         public string ServiceDnsName { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 11)]
+        [Parameter(Mandatory = false, Position = 12)]
         public IEnumerable<string> TagsRequiredToPlace { get; set; }
 
         /// <summary>
         /// </summary>
-        [Parameter(Mandatory = false, Position = 12)]
+        [Parameter(Mandatory = false, Position = 13)]
         public IEnumerable<string> TagsRequiredToRun { get; set; }
 
         /// <summary>
         /// Gets or sets NamesToAdd. Dynamic array for the names of the partitions to add.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 13, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateless_")]
         public IEnumerable<string> NamesToAdd { get; set; }
 
         /// <summary>
         /// Gets or sets NamesToRemove. Dynamic array for the names of the partitions to remove.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateful_")]
-        [Parameter(Mandatory = false, Position = 14, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateless_")]
         public IEnumerable<string> NamesToRemove { get; set; }
 
         /// <summary>
         /// Gets or sets TargetReplicaSetSize. The target replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 15, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Named__Stateful_")]
         public int? TargetReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets MinReplicaSetSize. The minimum replica set size as a number.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 16, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Named__Stateful_")]
         public int? MinReplicaSetSize { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaRestartWaitDurationSeconds. The duration, in seconds, between when a replica goes down and when
         /// a new replica is created.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 17, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Named__Stateful_")]
         public string ReplicaRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets QuorumLossWaitDurationSeconds. The maximum duration, in seconds, for which a partition is allowed to
         /// be in a state of quorum loss.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 18, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Named__Stateful_")]
         public string QuorumLossWaitDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets StandByReplicaKeepDurationSeconds. The definition on how long StandBy replicas should be maintained
         /// before being removed.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 19, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Named__Stateful_")]
         public string StandByReplicaKeepDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets ServicePlacementTimeLimitSeconds. The duration for which replicas can stay InBuild before reporting
         /// that build is stuck.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 20, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Named__Stateful_")]
         public string ServicePlacementTimeLimitSeconds { get; set; }
 
         /// <summary>
@@ -195,32 +203,32 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// has not finished build. If desired behavior is to drop it as soon as possible the value of this property is true,
         /// if not it is false.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 21, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Named__Stateful_")]
         public bool? DropSourceReplicaOnMove { get; set; }
 
         /// <summary>
         /// Gets or sets ReplicaLifecycleDescription. Defines how replicas of this service will behave during their lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 22, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Named__Stateful_")]
         public ReplicaLifecycleDescription ReplicaLifecycleDescription { get; set; }
 
         /// <summary>
         /// Gets or sets AuxiliaryReplicaCount. The auxiliary replica count as a number. To use Auxiliary replicas, the
         /// following must be true: AuxiliaryReplicaCount &lt; (TargetReplicaSetSize+1)/2 and TargetReplicaSetSize >=3.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 23, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Named__Stateful_")]
         public int? AuxiliaryReplicaCount { get; set; }
 
         /// <summary>
         /// Gets or sets ServiceSensitivityDescription. Defines default levels of replica sensitivity of this service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 24, ParameterSetName = "_Named__Stateful_")]
+        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Named__Stateful_")]
         public ServiceSensitivityDescription ServiceSensitivityDescription { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceCount. The instance count.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 25, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
         public int? InstanceCount { get; set; }
 
         /// <summary>
@@ -230,7 +238,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of
         /// nodes on which the instances are allowed to be placed according to the placement constraints on the service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 26, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstanceCount { get; set; }
 
         /// <summary>
@@ -241,7 +249,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// number of nodes on which the instances are allowed to be placed according to the placement constraints on the
         /// service.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 27, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateless_")]
         public int? MinInstancePercentage { get; set; }
 
         /// <summary>
@@ -258,14 +266,14 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// - Close existing connections after in-flight requests have completed.
         /// - Connect to a different instance of the service partition for future requests.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 28, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateless_")]
         public string InstanceCloseDelayDurationSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets InstanceLifecycleDescription. Defines how instances of this service will behave during their
         /// lifecycle.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 29, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateless_")]
         public InstanceLifecycleDescription InstanceLifecycleDescription { get; set; }
 
         /// <summary>
@@ -276,7 +284,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// The default value is 0, which indicates that when stateless instance goes down, Service Fabric will immediately
         /// start building its replacement.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 30, ParameterSetName = "_Named__Stateless_")]
+        [Parameter(Mandatory = false, Position = 31, ParameterSetName = "_Named__Stateless_")]
         public string InstanceRestartWaitDurationSeconds { get; set; }
 
         /// <summary>
@@ -284,7 +292,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
         /// time duration that the client is willing to wait for the requested operation to complete. The default value for
         /// this parameter is 60 seconds.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 31)]
+        [Parameter(Mandatory = false, Position = 32)]
         public long? ServerTimeout { get; set; }
 
         /// <inheritdoc/>
@@ -313,6 +321,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     loadMetrics: this.LoadMetrics,
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
+                    capacityReleaseAction: this.CapacityReleaseAction,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
                     serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code
@@ -337,6 +346,7 @@ namespace Microsoft.ServiceFabric.Powershell.Http
                     loadMetrics: this.LoadMetrics,
                     servicePlacementPolicies: this.ServicePlacementPolicies,
                     defaultMoveCost: this.DefaultMoveCost,
+                    capacityReleaseAction: this.CapacityReleaseAction,
                     scalingPolicies: this.ScalingPolicies,
                     serviceDnsName: this.ServiceDnsName,
                     serviceTags: serviceTags, // Hand-coded to avoid compiler errors in generated code

--- a/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -2202,6 +2202,108 @@
     </command:command>
     <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
             <command:details>
+                <command:name>Get-SFCapacityReleaseLevel</command:name>
+                <command:verb>Get</command:verb>
+                <command:noun>CapacityReleaseLevel</command:noun>
+                <maml:description>
+                    <maml:para>Gets the current capacity release level for the cluster.</maml:para>
+                </maml:description>
+            </command:details>
+            <command:syntax>
+            </command:syntax>
+            <maml:description>
+                <maml:para>Gets the capacity release level currently applied to the Service Fabric cluster.</maml:para>
+            </maml:description>
+            <command:parameters>
+            <command:parameter required="false" position="0">
+                <maml:name>ServerTimeout</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            </command:parameters>
+    </command:command>
+    <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+            <command:details>
+                <command:name>Set-SFCapacityReleaseLevel</command:name>
+                <command:verb>Set</command:verb>
+                <command:noun>CapacityReleaseLevel</command:noun>
+                <maml:description>
+                    <maml:para>Sets the capacity release level for the cluster.</maml:para>
+                </maml:description>
+            </command:details>
+            <command:syntax>
+            </command:syntax>
+            <maml:description>
+                <maml:para>Sets the capacity release level applied to the Service Fabric cluster.</maml:para>
+            </maml:description>
+            <command:parameters>
+            <command:parameter required="true" position="0">
+                <maml:name>Level</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The capacity release level to set for the cluster. Possible values include: 'None', 'Minor', 'Major'
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="true">CapacityReleaseLevel?</command:parameterValue>
+                <dev:type>
+                    <maml:name>CapacityReleaseLevel?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="1">
+                <maml:name>ServerTimeout</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            </command:parameters>
+    </command:command>
+    <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+            <command:details>
+                <command:name>Get-SFCapacityReleaseEstimation</command:name>
+                <command:verb>Get</command:verb>
+                <command:noun>CapacityReleaseEstimation</command:noun>
+                <maml:description>
+                    <maml:para>Gets capacity release estimates for the cluster.</maml:para>
+                </maml:description>
+            </command:details>
+            <command:syntax>
+            </command:syntax>
+            <maml:description>
+                <maml:para>Gets capacity release estimates for cluster metrics at the available capacity release levels.
+                
+                Runtimes that do not yet include the Placement and Load Balancing implementation for this operation return an OperationNotSupported error.
+                </maml:para>
+            </maml:description>
+            <command:parameters>
+            <command:parameter required="false" position="0">
+                <maml:name>ServerTimeout</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The server timeout for performing the operation in seconds. This timeout specifies the time duration that the client is willing to wait for the requested operation to complete. The default value for this parameter is 60 seconds.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            </command:parameters>
+    </command:command>
+    <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+            <command:details>
                 <command:name>Switch-SFVerboseServicePlacementHealthReporting</command:name>
                 <command:verb>Switch</command:verb>
                 <command:noun>VerboseServicePlacementHealthReporting</command:noun>

--- a/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -2287,6 +2287,30 @@
             </maml:description>
             <command:parameters>
             <command:parameter required="false" position="0">
+                <maml:name>ContinuationToken</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The continuation token to obtain the next set of results.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">ContinuationToken</command:parameterValue>
+                <dev:type>
+                    <maml:name>ContinuationToken</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="1">
+                <maml:name>MaxResults</maml:name>
+                <maml:Description>
+                    <maml:para>
+                    The maximum number of results to return. The value must be non-negative.
+                    </maml:para>
+                </maml:Description>
+            <command:parameterValue required="false">long?</command:parameterValue>
+                <dev:type>
+                    <maml:name>long?</maml:name>
+                </dev:type>
+            </command:parameter>
+            <command:parameter required="false" position="2">
                 <maml:name>ServerTimeout</maml:name>
                 <maml:Description>
                     <maml:para>

--- a/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
+++ b/src/Powershell.Http/Generated/psxml/Microsoft.ServiceFabric.Powershell.Http-Help.xml
@@ -2276,15 +2276,13 @@
                 <command:verb>Get</command:verb>
                 <command:noun>CapacityReleaseEstimation</command:noun>
                 <maml:description>
-                    <maml:para>Gets capacity release estimates for the cluster.</maml:para>
+                    <maml:para>Gets projected used capacity relative to cluster total capacity for each metric at each capacity release level.</maml:para>
                 </maml:description>
             </command:details>
             <command:syntax>
             </command:syntax>
             <maml:description>
-                <maml:para>Gets capacity release estimates for cluster metrics at the available capacity release levels.
-                
-                Runtimes that do not yet include the Placement and Load Balancing implementation for this operation return an OperationNotSupported error.
+                <maml:para>Reports projected used capacity relative to cluster total capacity for each cluster metric at each reported capacity release level.
                 </maml:para>
             </maml:description>
             <command:parameters>


### PR DESCRIPTION
## Summary

- add generated HTTP client APIs for getting and setting the cluster capacity release level
- add capacity release estimation models and JSON converters, including `Items` and `RecommendedLevel`
- add generated PowerShell cmdlets and help for the capacity release operations
- target Service Fabric REST API version 11.9
- project `CapacityReleaseAction` through generated service create, update, query, JSON converter, and PowerShell surfaces without changing existing positional parameters

## Validation

- `dotnet build -graph src\Powershell.Http\Microsoft.ServiceFabric.Powershell.Http.csproj -c Release --no-restore`