### PR TITLE
Limit reader quotas in ExceptionDeserializer

### DIFF
--- a/src/Services.Remoting/V2/Client/ExceptionDeserializer.cs
+++ b/src/Services.Remoting/V2/Client/ExceptionDeserializer.cs
@@ -18,7 +18,16 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Client
 {
     sealed class ExceptionDeserializer
     {
+        const int MaxItemsInObjectGraph = 10_000;
         static readonly string TraceEventType = "ExceptionDeserializer";
+        static readonly XmlDictionaryReaderQuotas readerQuotas = new()
+        {
+            MaxDepth = 64,
+            MaxStringContentLength = 1024 * 1024,
+            MaxArrayLength = 16 * 1024,
+            MaxBytesPerRead = 4 * 1024,
+            MaxNameTableCharCount = 16 * 1024,
+        };
         readonly IEnumerable<IExceptionConvertor> convertors;
 
         public ExceptionDeserializer(IEnumerable<IExceptionConvertor> convertors)
@@ -98,12 +107,12 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Client
 
         RemoteException2 DeserializeRemoteException2(byte[] buffer)
         {
-            var settings = new DataContractSerializerSettings { MaxItemsInObjectGraph = int.MaxValue };
+            var settings = new DataContractSerializerSettings { MaxItemsInObjectGraph = MaxItemsInObjectGraph };
             var serializer = new DataContractSerializer(typeof(RemoteException2), settings);
 
             try
             {
-                using var reader = XmlDictionaryReader.CreateBinaryReader(buffer, XmlDictionaryReaderQuotas.Max);
+                using var reader = XmlDictionaryReader.CreateBinaryReader(buffer, readerQuotas);
                 return (RemoteException2)serializer.ReadObject(reader);
             }
             catch (Exception e)

--- a/test/Services.Remoting/ExceptionDeserializerTest.cs
+++ b/test/Services.Remoting/ExceptionDeserializerTest.cs
@@ -5,8 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Fabric;
+using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.ServiceFabric.Services.Communication;
 using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2;
@@ -129,12 +132,12 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
 
         public class DeserializeRemoteExceptionAndThrowAsync : ExceptionDeserializerTest
         {
+            readonly ExceptionDeserializer sut = ExceptionDeserializer.CreateDefault([]);
+
             [Fact]
             public async Task ThrowsOriginalExceptionIfItIsKnownExceptionTypeAsync()
             {
                 // Arrange
-                var exceptionDeserializer = ExceptionDeserializer.CreateDefault(Enumerable.Empty<IExceptionConvertor>());
-
                 var originalException = new FabricInsufficientMaxLoadCapacityException(fuzzy.String());
 
                 List<ArraySegment<byte>> serializedException = exceptionSerializer.SerializeRemoteException(originalException);
@@ -143,7 +146,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
                 // Act & Assert
                 AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () =>
                     {
-                        await exceptionDeserializer.DeserializeRemoteExceptionAndThrowAsync(stream);
+                        await sut.DeserializeRemoteExceptionAndThrowAsync(stream);
                     });
 
                 Exception innerException = exception.Flatten().InnerException;
@@ -151,12 +154,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
                 Assert.Equal(originalException.Message, innerException.Message);
             }
 
-                        [Fact]
+            [Fact]
             public async Task ThrowsServiceExceptionForUnknownExceptions()
             {
                 // Arrange
-                var exceptionDeserializer = ExceptionDeserializer.CreateDefault(Enumerable.Empty<IExceptionConvertor>());
-
                 var originalException = new UnknownException(fuzzy.String());
 
                 List<ArraySegment<byte>> serializedException = exceptionSerializer.SerializeRemoteException(originalException);
@@ -165,12 +166,65 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
                 // Act & Assert
                 AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () =>
                     {
-                        await exceptionDeserializer.DeserializeRemoteExceptionAndThrowAsync(stream);
+                        await sut.DeserializeRemoteExceptionAndThrowAsync(stream);
                     });
 
                 Exception innerException = exception.Flatten().InnerException;
                 Assert.IsType<ServiceException>(innerException);
                 Assert.Equal(originalException.Message, innerException.Message);
+            }
+
+            [Fact]
+            public async Task ThrowsServiceExceptionWhenObjectGraphExceedsQuota()
+            {
+                int maxItems = typeof(ExceptionDeserializer).Field<int>().Value;
+                RemoteException2 remoteException = RemoteException();
+                remoteException.InnerExceptions = [.. Enumerable.Range(0, maxItems).Select(_ => RemoteException())];
+                using MemoryStream stream = Serialize(remoteException);
+
+                _ = await Assert.ThrowsAsync<ServiceException>(() => sut.DeserializeRemoteExceptionAndThrowAsync(stream));
+            }
+
+            [Fact]
+            public async Task ThrowsServiceExceptionWhenStringContentExceedsQuota()
+            {
+                XmlDictionaryReaderQuotas quotas = typeof(ExceptionDeserializer).Field<XmlDictionaryReaderQuotas>().Value;
+                RemoteException2 remoteException = RemoteException();
+                remoteException.Message = new string('a', quotas.MaxStringContentLength + 1);
+                using MemoryStream stream = Serialize(remoteException);
+
+                _ = await Assert.ThrowsAsync<ServiceException>(() => sut.DeserializeRemoteExceptionAndThrowAsync(stream));
+            }
+
+            [Fact]
+            public async Task ThrowsServiceExceptionWhenXmlDepthExceedsQuota()
+            {
+                XmlDictionaryReaderQuotas quotas = typeof(ExceptionDeserializer).Field<XmlDictionaryReaderQuotas>().Value;
+                RemoteException2 remoteException = RemoteException();
+                for (int depth = 0; depth < quotas.MaxDepth; depth++)
+                    remoteException = RemoteException(remoteException);
+                using MemoryStream stream = Serialize(remoteException);
+
+                _ = await Assert.ThrowsAsync<ServiceException>(() => sut.DeserializeRemoteExceptionAndThrowAsync(stream));
+            }
+
+            static RemoteException2 RemoteException(RemoteException2 inner = null) =>
+                new()
+                {
+                    Type = typeof(UnknownException).FullName,
+                    Message = fuzzy.String(),
+                    InnerExceptions = inner is null ? null : [inner],
+                };
+
+            static MemoryStream Serialize(RemoteException2 remoteException)
+            {
+                var settings = new DataContractSerializerSettings { MaxItemsInObjectGraph = int.MaxValue };
+                var serializer = new DataContractSerializer(typeof(RemoteException2), settings);
+                using MemoryStream serialized = new();
+                using var writer = XmlDictionaryWriter.CreateBinaryWriter(serialized);
+                serializer.WriteObject(writer, remoteException);
+                writer.Flush();
+                return new MemoryStream(serialized.ToArray());
             }
         }
 


### PR DESCRIPTION
`ExceptionDeserializer` currently deserializes potentially attacker-controlled remoting exception payloads using:

- `XmlDictionaryReaderQuotas.Max`
- `MaxItemsInObjectGraph = int.MaxValue`
Although exception deserialization now uses fixed-type `DataContractSerializer` and is not vulnerable to BinaryFormatter/NetDataContractSerializer RCE, unbounded quotas permit malicious payloads to consume excessive memory, CPU, or stack space.

Replace the unlimited settings with exception-specific finite quotas:

- Maximum XML depth: 64
- Maximum string content: 1 MiB
- Maximum array length: 16K
- Maximum bytes per read: 4 KiB
- Maximum name-table characters: 16K
- Maximum object graph: 10K items

## Quota Rationale

- **XML depth: 64.** Remoting exceptions normally use a shallow tree and the sender defaults to an exception depth of two.
	A limit of 64 leaves substantial compatibility headroom while rejecting pathological nesting before recursive conversion can
	exhaust the stack.
- **String content: 1 MiB.** Exception messages and stack traces can legitimately exceed the framework default of 8 KiB. One
	MiB accommodates unusually large diagnostic text while preventing a single string from consuming an unbounded amount of
	memory.
- **Array length: 16K.** This retains the framework default. It is sufficient for exception data and inner-exception
	collections while bounding collection allocation.
- **Bytes per read: 4 KiB.** This retains the framework default. Increasing it provides little benefit for the small, fixed
	exception contract and would allow larger allocations during individual reader operations.
- **Name-table characters: 16K.** This retains the framework default. `RemoteException2` has a fixed schema with few element
	names, so legitimate payloads require substantially less capacity.
- **Object graph: 10K items.** XML reader quotas do not bound the total number of deserialized objects. Ten thousand items
	provide ample capacity for legitimate exception trees, data entries, and strings while bounding aggregate allocation and
	processing work.

Fabric Transport's default 4 MiB `MaxMessageSize` remains the outer wire-size limit. These quotas provide defense in depth
because the deserialized object graph can consume considerably more memory than its serialized representation and the transport
limit is configurable.

This work provides defense in depth against denial of service.